### PR TITLE
Update Docker Image Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Docker Image
 
 A docker image has kindly been provided by [christronyxyocum](https://github.com/christronyxyocum):
 
-https://hub.docker.com/r/tronyx/docker-plpp/
+https://hub.docker.com/r/tronyx/plpp
 
 
 Description


### PR DESCRIPTION
Updated the Docker image link to the more recent image.

tronyx/docker-plpp was last updated over a year ago.
tronyx/plpp was last updated 3 months ago. Also, searching for plpp on Docker Hub shows only tronyx/plpp.